### PR TITLE
Fix collector template env indention & dependencies support env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ NAME            CHART VERSION	APP VERSION	DESCRIPTION
 $ git checkout <this repo> <path>
 $ helm install --upgrade <flags> <path>/charts/zipkin
 ```
+

--- a/README.md
+++ b/README.md
@@ -26,4 +26,3 @@ NAME            CHART VERSION	APP VERSION	DESCRIPTION
 $ git checkout <this repo> <path>
 $ helm install --upgrade <flags> <path>/charts/zipkin
 ```
-

--- a/charts/zipkin/Chart.yaml
+++ b/charts/zipkin/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
   data needed to troubleshoot latency problems in service architectures.
   Features include both the collection and lookup of this data.
 icon: https://zipkin.io/public/img/logo_png/zipkin_vertical_grey_gb.png
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.21.0
 keywords:
   - tracing

--- a/charts/zipkin/templates/collector/deployment.yaml
+++ b/charts/zipkin/templates/collector/deployment.yaml
@@ -26,8 +26,8 @@ spec:
           env:
             - name: QUERY_PORT
               value: {{ .Values.collector.service.port | quote }}
-            {{- range .Values.collector.env }}
-            - {{ . | toYaml }}
+            {{- with .Values.collector.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/zipkin/templates/dependencies/cronjob.yaml
+++ b/charts/zipkin/templates/dependencies/cronjob.yaml
@@ -21,10 +21,14 @@ spec:
           serviceAccountName: {{ include "zipkin.dependencies.serviceAccountName" . }}
           containers:
             - name: {{ .Chart.Name }}-dependencies
-              image: "{{ .Values.dependencies.image.repository }}:{{ .Values.dependencies.image.repository }}"
+              image: "{{ .Values.dependencies.image.repository }}:{{ .Values.dependencies.image.tag }}"
               imagePullPolicy: {{ .Values.dependencies.image.pullPolicy }}
               resources:
                 {{- toYaml .Values.collector.resources | nindent 16 }}
+              env:
+                {{- with .Values.collector.env }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
           {{- with .Values.collector.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/zipkin/values.yaml
+++ b/charts/zipkin/values.yaml
@@ -61,6 +61,8 @@ collector:
 
   affinity: {}
 
+  env: []
+
 ui:
   replicaCount: 1
   hpa:
@@ -154,3 +156,5 @@ dependencies:
   tolerations: []
 
   affinity: {}
+
+  env: []


### PR DESCRIPTION
When `collector.env` is set in values overrides, the collector template gives error:
```
Error: YAML parse error on zipkin/templates/collector/deployment.yaml: error converting YAML to JSON: yaml: line 36: mapping values are not allowed in this context
```